### PR TITLE
Updated gatsby-node to use Gatsby v2 Babel Plugin syntax.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,19 +4,12 @@ const touch = require('touch')
 const glob = require('globby')
 
 // Add babel plugin
-exports.modifyBabelrc = ({ babelrc }) => {
-	return {
-		...babelrc,
-		plugins: babelrc.plugins.concat([
-			[
-				'styled-jsx/babel',
-				{
-					'plugins': ['styled-jsx-plugin-postcss']
-				}
-			]
-		]),
-	}
-}
+exports.onCreateBabelConfig = ({ actions }) => {
+	actions.setBabelPlugin({
+		name: 'styled-jsx/babel',
+		options: { plugins: ['styled-jsx-plugin-postcss'] },
+	});
+};
 
 // Watch CSS files
 exports.modifyWebpackConfig = ({ config, stage }, options) => {


### PR DESCRIPTION
Gatsby 2 has changed the syntax to add a babel plugin.

See:
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/migrating-from-v1-to-v2.md#change-modifybabelrc-to-oncreatebabelconfig

I have modified the gatsby-node.js file to work with this update.