### PR TITLE
Updated gatsby-node to use onCreateWebpackConfig.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -12,7 +12,7 @@ exports.onCreateBabelConfig = ({ actions }) => {
 };
 
 // Watch CSS files
-exports.modifyWebpackConfig = ({ config, stage }, options) => {
+exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
 	if (stage === `develop`) {
 		options = {
 			watchCss: true,
@@ -37,5 +37,5 @@ exports.modifyWebpackConfig = ({ config, stage }, options) => {
 		}
 	}
 
-	return config
+	return actions
 }

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,4 +1,4 @@
-import flush from "styled-jsx/server"
+const flush = require('styled-jsx/server').default
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 	if (process.env.NODE_ENV === `production`) {
 		const css = flush()


### PR DESCRIPTION
modifyWebpackConfig has changed to onCreateWebpackConfig in Gatsby v2.
https://next.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-modifywebpackconfig-to-oncreatewebpackconfig

Didn't notice this until I tried to build my site.